### PR TITLE
Update assert to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sunesimonsen/fdb-blobs
 go 1.19
 
 require (
-	github.com/alecthomas/assert/v2 v2.2.1
+	github.com/alecthomas/assert/v2 v2.2.2
 	github.com/apple/foundationdb/bindings/go v0.0.0-20221208173428-5c644f20e3c5
 	github.com/oklog/ulid/v2 v2.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/alecthomas/assert/v2 v2.2.1 h1:XivOgYcduV98QCahG8T5XTezV5bylXe+lBxLG2K2ink=
-github.com/alecthomas/assert/v2 v2.2.1/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
+github.com/alecthomas/assert/v2 v2.2.2 h1:Z/iVC0xZfWTaFNE6bA3z07T86hd45Xe2eLt6WVy2bbk=
+github.com/alecthomas/assert/v2 v2.2.2/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/apple/foundationdb/bindings/go v0.0.0-20221208173428-5c644f20e3c5 h1:DgmGajvfsMqNaFb4jA1HRJ5sI7tin1su5fFTbhYCV9o=

--- a/store_test.go
+++ b/store_test.go
@@ -72,13 +72,7 @@ func TestCreateRead(t *testing.T) {
 			data, err := s.Read(ctx, id)
 			assert.NoError(t, err)
 
-			assert.Equal(t, len(input), len(data), "lengths")
-
-			// TODO this might be fixed in assert.Equal
-			// see https://github.com/alecthomas/assert/pull/11
-			if len(input) > 0 && len(data) > 0 {
-				assert.Equal(t, input, data, "length: %d", length)
-			}
+			assert.Equal(t, input, data, "length: %d", length)
 		}
 	})
 }
@@ -192,10 +186,6 @@ func FuzzChunkSizes(f *testing.F) {
 		data, err := s.Read(ctx, id)
 		assert.NoError(t, err)
 
-		// TODO this might be fixed in assert.Equal
-		// see https://github.com/alecthomas/assert/pull/11
-		if len(input) > 0 && len(data) > 0 {
-			assert.Equal(t, input, data, "chunkSize: %d, chunksPerTransaction %d", chunkSize, chunksPerTransaction)
-		}
+		assert.Equal(t, input, data, "chunkSize: %d, chunksPerTransaction %d", chunkSize, chunksPerTransaction)
 	})
 }


### PR DESCRIPTION
This has a fix for comparing byte arrays