### PR TITLE
Use int a the return type of Len

### DIFF
--- a/store.go
+++ b/store.go
@@ -32,7 +32,7 @@ type BlobStore interface {
 	CommitUpload(tr fdb.Transaction, uploadToken UploadToken) Id
 	Create(ctx context.Context, r io.Reader) (Id, error)
 	BlobReader(id Id) (BlobReader, error)
-	Len(id Id) (uint64, error)
+	Len(id Id) (int, error)
 	CreatedAt(id Id) (time.Time, error)
 }
 
@@ -127,18 +127,18 @@ func (bs *fdbBlobStore) Read(cxt context.Context, id Id) ([]byte, error) {
 	}
 }
 
-func (bs *fdbBlobStore) Len(id Id) (uint64, error) {
+func (bs *fdbBlobStore) Len(id Id) (int, error) {
 	length, err := bs.db.ReadTransact(func(tr fdb.ReadTransaction) (any, error) {
 		data, error := tr.Get(tuple.Tuple{bs.ns, "blobs", id, "len"}).Get()
 
 		if len(data) == 0 {
-			return uint64(0), fmt.Errorf("%w: %q", BlobNotFoundError, id)
+			return 0, fmt.Errorf("%w: %q", BlobNotFoundError, id)
 		}
 
-		return decodeUInt64(data), error
+		return int(decodeUInt64(data)), error
 	})
 
-	return length.(uint64), err
+	return length.(int), err
 }
 
 func (bs *fdbBlobStore) write(cxt context.Context, id Id, r io.Reader) error {

--- a/store_test.go
+++ b/store_test.go
@@ -138,7 +138,7 @@ func TestLen(t *testing.T) {
 			id, err := s.Create(ctx, bytes.NewReader(input))
 			assert.NoError(t, err)
 
-			want := uint64(length)
+			want := length
 			got, err := s.Len(id)
 			assert.NoError(t, err)
 


### PR DESCRIPTION
This will integrate better with other libraries and the size of a blob is never going to be this big.