### PR TITLE
Support multiple chunk sizes

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -34,13 +34,12 @@ func (blob *Blob) Len() (uint64, error) {
 }
 
 func (blob *Blob) CreatedAt() (time.Time, error) {
-	createdAt, err := blob.db.ReadTransact(func(tr fdb.ReadTransaction) (any, error) {
-		data, error := tr.Get(blob.dir.Sub("createdAt")).Get()
+	data, err := blob.db.ReadTransact(func(tr fdb.ReadTransaction) (any, error) {
+		return tr.Get(blob.dir.Sub("createdAt")).Get()
 
-		return time.Unix(int64(decodeUInt64(data)), 0), error
 	})
 
-	return createdAt.(time.Time), err
+	return time.Unix(int64(decodeUInt64(data.([]byte))), 0), err
 }
 
 func (blob *Blob) Reader() (*Reader, error) {

--- a/store.go
+++ b/store.go
@@ -108,10 +108,20 @@ func (store *Store) Blob(id Id) (*Blob, error) {
 		return nil, err
 	}
 
+	data, err := store.db.ReadTransact(func(tr fdb.ReadTransaction) (any, error) {
+		return tr.Get(blobDir.Sub("chunkSize")).Get()
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	chunkSize := int(decodeUInt64(data.([]byte)))
+
 	blob := &Blob{
 		db:                   store.db,
 		dir:                  blobDir,
-		chunkSize:            store.chunkSize,
+		chunkSize:            chunkSize,
 		chunksPerTransaction: store.chunksPerTransaction,
 	}
 

--- a/uploads.go
+++ b/uploads.go
@@ -55,6 +55,7 @@ func (store *Store) write(ctx context.Context, blobDir subspace.Subspace, r io.R
 
 	_, err := store.db.Transact(func(tr fdb.Transaction) (any, error) {
 		tr.Set(blobDir.Sub("len"), encodeUInt64(written))
+		tr.Set(blobDir.Sub("chunkSize"), encodeUInt64(uint64(store.chunkSize)))
 		return nil, nil
 	})
 


### PR DESCRIPTION
When you store a blob we record the chunk size, so we can use that later when reading the blob.