### PR TITLE
Simplify the API (Major)

### DIFF
--- a/blob_example_test.go
+++ b/blob_example_test.go
@@ -1,24 +1,10 @@
 package blobs
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log"
 )
-
-func ExampleBlob_Content() {
-	ctx := context.Background()
-	blob := createTestBlob()
-
-	content, err := blob.Content(ctx)
-	if err != nil {
-		log.Fatal("Could not get blob content")
-	}
-
-	fmt.Printf("Blob content: %s", content)
-	// Output: Blob content: My blob content
-}
 
 func ExampleBlob_CreatedAt() {
 	blob := createTestBlob()
@@ -47,10 +33,7 @@ func ExampleBlob_Len() {
 func ExampleBlob_Reader() {
 	blob := createTestBlob()
 
-	r, err := blob.Reader()
-	if err != nil {
-		log.Fatal("Could not get blob reader")
-	}
+	r := blob.Reader()
 
 	lr := io.LimitReader(r, 10)
 

--- a/blob_test.go
+++ b/blob_test.go
@@ -2,7 +2,6 @@ package blobs
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"testing"
 	"time"
@@ -21,8 +20,7 @@ func TestLen(t *testing.T) {
 			_, err := rand.Read(input)
 			assert.NoError(t, err)
 
-			ctx := context.Background()
-			blob, err := s.Create(ctx, bytes.NewReader(input))
+			blob, err := s.Create(bytes.NewReader(input))
 			assert.NoError(t, err)
 
 			want := length
@@ -42,8 +40,7 @@ func TestCreatedAt(t *testing.T) {
 		_, err := rand.Read(input)
 		assert.NoError(t, err)
 
-		ctx := context.Background()
-		blob, err := s.Create(ctx, bytes.NewReader(input))
+		blob, err := s.Create(bytes.NewReader(input))
 		assert.NoError(t, err)
 
 		createdAt, err := blob.CreatedAt()

--- a/options_example_test.go
+++ b/options_example_test.go
@@ -1,15 +1,14 @@
 package blobs
 
 import (
-	"context"
 	"fmt"
+	"io"
 	"log"
 	"strings"
 	"time"
 )
 
 func ExampleWithChunkSize() {
-	ctx := context.Background()
 	db := fdbConnect()
 
 	store, err := NewStore(db, testNamespace(), WithChunkSize(256))
@@ -17,12 +16,12 @@ func ExampleWithChunkSize() {
 		log.Fatalln("Could not create store")
 	}
 
-	blob, err := store.Create(ctx, strings.NewReader("Blob content"))
+	blob, err := store.Create(strings.NewReader("Blob content"))
 	if err != nil {
 		log.Fatal("Could not create blob")
 	}
 
-	content, err := blob.Content(ctx)
+	content, err := io.ReadAll(blob.Reader())
 	if err != nil {
 		log.Fatal("Could not read blob content")
 	}
@@ -32,7 +31,6 @@ func ExampleWithChunkSize() {
 }
 
 func ExampleWithChunksPerTransaction() {
-	ctx := context.Background()
 	db := fdbConnect()
 
 	store, err := NewStore(db, testNamespace(), WithChunksPerTransaction(10))
@@ -40,12 +38,12 @@ func ExampleWithChunksPerTransaction() {
 		log.Fatalln("Could not create store")
 	}
 
-	blob, err := store.Create(ctx, strings.NewReader("Blob content"))
+	blob, err := store.Create(strings.NewReader("Blob content"))
 	if err != nil {
 		log.Fatal("Could not create blob")
 	}
 
-	content, err := blob.Content(ctx)
+	content, err := io.ReadAll(blob.Reader())
 	if err != nil {
 		log.Fatal("Could not read blob content")
 	}
@@ -55,7 +53,6 @@ func ExampleWithChunksPerTransaction() {
 }
 
 func ExampleWithSystemTime() {
-	ctx := context.Background()
 	db := fdbConnect()
 
 	now, _ := time.Parse(time.RFC3339, "2023-01-01T00:00:00Z")
@@ -66,7 +63,7 @@ func ExampleWithSystemTime() {
 		log.Fatalln("Could not create store")
 	}
 
-	blob, err := store.Create(ctx, strings.NewReader("Blob content"))
+	blob, err := store.Create(strings.NewReader("Blob content"))
 	if err != nil {
 		log.Fatal("Could not create blob")
 	}
@@ -81,7 +78,6 @@ func ExampleWithSystemTime() {
 }
 
 func ExampleWithIdGenerator() {
-	ctx := context.Background()
 	db := fdbConnect()
 
 	idGenerator := &TestIdgenerator{}
@@ -91,7 +87,7 @@ func ExampleWithIdGenerator() {
 	}
 
 	for i := 0; i < 3; i++ {
-		blob, err := store.Create(ctx, strings.NewReader("Blob content"))
+		blob, err := store.Create(strings.NewReader("Blob content"))
 		if err != nil {
 			log.Fatal("Could not create blob")
 		}

--- a/removed.go
+++ b/removed.go
@@ -21,6 +21,10 @@ func (store *Store) RemoveBlob(id Id) error {
 		removedPath := append(store.removedDir.GetPath(), string(id))
 		dst, err := blobDir.MoveTo(tr, removedPath)
 
+		if err != nil {
+			return err
+		}
+
 		unixTimestamp := store.systemTime.Now().Unix()
 		tr.Set(dst.Sub("deletedAt"), encodeUInt64(uint64(unixTimestamp)))
 

--- a/removed_test.go
+++ b/removed_test.go
@@ -1,8 +1,8 @@
 package blobs
 
 import (
-	"context"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -14,9 +14,7 @@ func TestRemoveBlob(t *testing.T) {
 	store := createTestStore(WithChunkSize(100))
 
 	t.Run("can't retrieve blob after it is removed", func(t *testing.T) {
-		ctx := context.Background()
-
-		blob, err := store.Create(ctx, strings.NewReader("blob"))
+		blob, err := store.Create(strings.NewReader("blob"))
 		assert.NoError(t, err)
 		err = store.RemoveBlob(blob.Id())
 		assert.NoError(t, err)
@@ -27,14 +25,12 @@ func TestRemoveBlob(t *testing.T) {
 	})
 
 	t.Run("already retrieved blobs are accessible", func(t *testing.T) {
-		ctx := context.Background()
-
-		blob, err := store.Create(ctx, strings.NewReader("blob"))
+		blob, err := store.Create(strings.NewReader("blob"))
 		assert.NoError(t, err)
 		err = store.RemoveBlob(blob.Id())
 		assert.NoError(t, err)
 
-		data, err := blob.Content(ctx)
+		data, err := io.ReadAll(blob.Reader())
 		assert.NoError(t, err)
 
 		assert.Equal(t, "blob", string(data))
@@ -52,11 +48,9 @@ func TestDeleteRemovedBlobsBefore(t *testing.T) {
 	)
 
 	t.Run("Test that old uploads can be cleaned", func(t *testing.T) {
-		ctx := context.Background()
-
 		st.Time = date.AddDate(0, -2, 0)
 		for i := 0; i < 5; i++ {
-			blob, err := store.Create(ctx, strings.NewReader("content"))
+			blob, err := store.Create(strings.NewReader("content"))
 			assert.NoError(t, err)
 			err = store.RemoveBlob(blob.Id())
 			assert.NoError(t, err)
@@ -64,7 +58,7 @@ func TestDeleteRemovedBlobsBefore(t *testing.T) {
 
 		st.Time = date
 		for i := 0; i < 5; i++ {
-			blob, err := store.Create(ctx, strings.NewReader("content"))
+			blob, err := store.Create(strings.NewReader("content"))
 			assert.NoError(t, err)
 			err = store.RemoveBlob(blob.Id())
 			assert.NoError(t, err)

--- a/store.go
+++ b/store.go
@@ -1,7 +1,6 @@
 package blobs
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -106,8 +105,8 @@ func (store *Store) Blob(id Id) (*Blob, error) {
 }
 
 // Creates and returns a new blob with the content of the given reader r.
-func (store *Store) Create(ctx context.Context, r io.Reader) (*Blob, error) {
-	token, err := store.Upload(ctx, r)
+func (store *Store) Create(r io.Reader) (*Blob, error) {
+	token, err := store.Upload(r)
 	if err != nil {
 		return nil, err
 	}

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -1,7 +1,6 @@
 package blobs
 
 import (
-	"context"
 	"log"
 	"os"
 	"strconv"
@@ -46,10 +45,9 @@ func createTestBlob() *Blob {
 	st := &SystemTimeMock{Time: date}
 
 	store := createTestStore(WithSystemTime(st), WithIdGenerator(&TestIdgenerator{}))
-	ctx := context.Background()
 
 	r := strings.NewReader("My blob content")
-	blob, err := store.Create(ctx, r)
+	blob, err := store.Create(r)
 
 	if err != nil {
 		log.Fatal("Could not create blob")


### PR DESCRIPTION
I prematurely added context to the API, but given that I'm using readers and writers, you can just use context aware versions of those. 